### PR TITLE
remove the “-D__attribute__(A)=” CPP options for gio, gtk and gtk3, too

### DIFF
--- a/gio/gio.cabal
+++ b/gio/gio.cabal
@@ -81,7 +81,7 @@ Library
         default-language:   Haskell98
         default-extensions: ForeignFunctionInterface
 
-        cpp-options:    -U__BLOCKS__ -Ubool -D__attribute__(A)=
+        cpp-options:    -U__BLOCKS__ -Ubool -DGLIB_DISABLE_DEPRECATION_WARNINGS
         if os(darwin) || os(freebsd)
           cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn=
 

--- a/gtk/gtk.cabal-renamed
+++ b/gtk/gtk.cabal-renamed
@@ -381,7 +381,7 @@ Library
         -- needs to be imported from this module:
         x-Signals-Import: Graphics.UI.Gtk.General.Threading
         include-dirs:   .
-        cpp-options: -U__BLOCKS__ -D__attribute__(A)=
+        cpp-options: -U__BLOCKS__ -DGLIB_DISABLE_DEPRECATION_WARNINGS
         if os(darwin) || os(freebsd)
           cpp-options: -D_Nullable= -D_Nonnull=
         if !flag(deprecated)

--- a/gtk/gtk3.cabal
+++ b/gtk/gtk3.cabal
@@ -372,7 +372,7 @@ Library
         -- needs to be imported from this module:
         x-Signals-Import: Graphics.UI.Gtk.General.Threading
         include-dirs:   .
-        cpp-options: -DDISABLE_DEPRECATED -U__BLOCKS__ -D__attribute__(A)=
+        cpp-options: -DDISABLE_DEPRECATED -U__BLOCKS__ -DGLIB_DISABLE_DEPRECATION_WARNINGS
         if os(darwin) || os(freebsd)
           cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn=
         if os(windows)


### PR DESCRIPTION
This PR is an additional one for https://github.com/gtk2hs/gtk2hs/pull/289.

Maybe cairo too, but I have neither Darwin nor FreeBSD machine.

```diff
         if os(darwin) || os(freebsd)
-          cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull= -D_Noreturn=
+          cpp-options: -DGLIB_DISABLE_DEPRECATION_WARNINGS -D_Nullable= -D_Nonnull= -D_Noreturn=
```